### PR TITLE
Get package version from Git tags

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/django_coverage/__init__.py
+++ b/django_coverage/__init__.py
@@ -1,0 +1,6 @@
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,23 @@ from setuptools import find_packages, setup
 
 
 def readme():
-    with open('README.md') as f:
+    with open("README.md") as f:
         return f.read()
 
 
 setup(
-    name='django-coverage',
-    version='0.1.0',
-    license='MIT',
-    description='Adds coverage reporting to Django test command',
+    name="django-coverage",
+    license="MIT",
+    use_scm_version=True,
+    description="Adds coverage reporting to Django test command",
     long_description=readme(),
-    keywords='django test coverage',
-    author='Vacasa, LLC',
-    author_email='opensource@vacasa.com',
-    url='https://github.com/vacasa/django-coverage',
-    packages=find_packages(exclude=['tests*']),
+    keywords="django test coverage",
+    author="Vacasa, LLC",
+    author_email="opensource@vacasa.com",
+    url="https://github.com/vacasa/django-coverage",
+    packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    install_requires=[
-        'django',
-        'coverage'
-    ],
-    zip_safe=False
+    install_requires=["django", "coverage"],
+    setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
+    zip_safe=False,
 )


### PR DESCRIPTION
# What
Auto-set package version based on Git tags via [setupstools_scm](https://github.com/pypa/setuptools_scm/).

# Test
- [ ] In an empty directory, run `pipenv install https://github.com/Vacasa/django-coverage/archive/0.1.1.tar.gz`
-  [ ] `pipenv shell`, then `import django_coverage` and `django_coverage.__version__` should output `'0.1.1'`, indicating the version has been determined automatically from the Git tag.